### PR TITLE
下のnewsの表示を767px以下の横幅の時に大きく見えるように

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -162,6 +162,13 @@ ul.news{
   overflow-y: scroll;
 }
 
+@media screen and (max-width:767px){
+  .news-box{
+    width: auto;
+    height: auto;
+  }
+} 
+
 .news-box a {
   width: 100%;
   text-decoration: none;


### PR DESCRIPTION
Xemonoサイトの下のnewsの表示を767px以下の横幅の時に大きく見えるように、文章もちゃんと表示されるように変えた